### PR TITLE
Make shadeutil a little better

### DIFF
--- a/cmd/shade/shade.go
+++ b/cmd/shade/shade.go
@@ -8,11 +8,13 @@ import (
 	"os"
 	"os/signal"
 	"os/user"
+	"path"
 	"strconv"
 	"time"
 
 	"bazil.org/fuse"
 
+	"github.com/asjoyner/shade"
 	"github.com/asjoyner/shade/cache"
 	"github.com/asjoyner/shade/config"
 	"github.com/asjoyner/shade/drive"
@@ -25,8 +27,11 @@ import (
 )
 
 var (
+	defaultConfig = path.Join(shade.ConfigDir(), "config.json")
+
 	readOnly   = flag.Bool("readonly", false, "Mount the filesystem read only.")
 	allowOther = flag.Bool("allow_other", false, "If other users are allowed to view the mounted filesystem.")
+	configFile = flag.String("config", defaultConfig, fmt.Sprintf("The shade config file. Defaults to %q", defaultConfig))
 )
 
 func main() {
@@ -39,7 +44,7 @@ func main() {
 	}
 
 	// read in the config
-	clients, err := config.Clients()
+	clients, err := config.Clients(*configFile)
 	if err != nil {
 		log.Fatalf("could not initialize clients: %s\n", err)
 	}

--- a/cmd/throw/throw.go
+++ b/cmd/throw/throw.go
@@ -19,8 +19,13 @@ import (
 	_ "github.com/asjoyner/shade/drive/memory"
 )
 
-// TODO(asjoyner): make chunksize a flag
-var chunksize = flag.Int("chunksize", 16*1024*1024, "size of a chunk stored in Drive, in bytes")
+var (
+	defaultConfig = path.Join(shade.ConfigDir(), "config.json")
+
+	// TODO(asjoyner): make chunksize a flag
+	chunksize  = flag.Int("chunksize", 16*1024*1024, "size of a chunk stored in Drive, in bytes")
+	configPath = flag.String("config", defaultConfig, "shade config file")
+)
 
 func main() {
 	flag.Usage = func() {
@@ -35,7 +40,7 @@ func main() {
 	}
 
 	// read in the config
-	clients, err := config.Clients()
+	clients, err := config.Clients(*configPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not initialize clients: %s\n", err)
 		os.Exit(1)

--- a/config/config.go
+++ b/config/config.go
@@ -4,15 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"path"
 
-	"github.com/asjoyner/shade"
 	"github.com/asjoyner/shade/drive"
 )
 
 // Read finds, reads, parses, and returns the config.
-func Read() ([]drive.Config, error) {
-	filename := configPath()
+func Read(filename string) ([]drive.Config, error) {
 	contents, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("ReadFile(%q): %s", filename, err)
@@ -44,13 +41,8 @@ func parseConfig(contents []byte) ([]drive.Config, error) {
 	return configs, nil
 }
 
-// configPath returns the path of the JSON config file.
-func configPath() string {
-	return path.Join(shade.ConfigDir(), "config.json")
-}
-
-func Clients() ([]drive.Client, error) {
-	configs, err := Read()
+func Clients(configFile string) ([]drive.Client, error) {
+	configs, err := Read(configFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse config: %s", err)
 	}

--- a/util.go
+++ b/util.go
@@ -1,23 +1,29 @@
 package shade
 
 import (
-	"fmt"
+	"log"
 	"os"
 	"path"
 	"runtime"
+)
+
+var (
+	// These are mockable for testing.
+	envFunc = os.Getenv
+	goos    = runtime.GOOS
 )
 
 // ConfigDir identifies the correct path to store persistent configuration data
 // on various operating systems.
 func ConfigDir() string {
 	dir := "."
-	switch runtime.GOOS {
+	switch goos {
 	case "darwin":
-		dir = path.Join(os.Getenv("HOME"), "Library", "Application Support", "shade")
+		dir = path.Join(envFunc("HOME"), "Library", "Application Support", "shade")
 	case "linux", "freebsd":
-		dir = path.Join(os.Getenv("HOME"), ".shade")
+		dir = path.Join(envFunc("HOME"), ".shade")
 	default:
-		fmt.Printf("TODO: ConfigDir on GOOS %q", runtime.GOOS)
+		log.Printf("TODO: ConfigDir on GOOS %q", goos)
 	}
 	return dir
 }

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,30 @@
+package shade
+
+import "testing"
+
+func TestConfigDir(t *testing.T) {
+	origGOOS := goos
+	origEnvFunc := envFunc
+	defer func() {
+		goos = origGOOS
+		envFunc = origEnvFunc
+	}()
+	envFunc = func(_ string) string {
+		return "/foo/bar"
+	}
+
+	for _, tt := range []struct {
+		goos string
+		want string
+	}{
+		{"linux", "/foo/bar/.shade"},
+		{"freebsd", "/foo/bar/.shade"},
+		{"darwin", "/foo/bar/Library/Application Support/shade"},
+		{"bogus", "."},
+	} {
+		goos = tt.goos
+		if got := ConfigDir(); got != tt.want {
+			t.Errorf("Wanted %q from ConfigDir() for GOOS = %q, but got %q", tt.want, tt.goos, got)
+		}
+	}
+}


### PR DESCRIPTION
Make shadeutil ls output a little better. Also adds the requirement that a config file path be passed to `shade.Clients()` and `shade.Read()`, and adds tests for `shade.ConfigDir()`.

Exampel of the new output of `shadeutil ls`:

``` shell
$ go run cmd/shadeutil/shadeutil.go ls -l -f ~/Source/shade/localdrive.config.json 
localdrive
 id (sha)                                                              size     chunksize chunks mtime           filename
 0  (06ab0b76266a9314b0a6970d1660e9dcbbfec0217cae05036ce5662f2cbb4a60) 11999829 16777216  1      Jan  1 00:00:00 DSC_0036.NEF
 1  (1ba6ae17f0cd8a0d10661836f4f3890908b439b20e87358eb68db2a277ae30de) 11999829 16777216  1      Jan  1 00:00:00 DSC_0035.NEF
 2  (987bc43318e7ad1687b6d9fa37143f931abead44162863da7033d2c4e762563a) 11999829 1024      11719  Jan  1 00:00:00 DSC_0035.NEF
 3  (d5b499544fb2354d6c3fcd9b3591903710d76834efc05601d1a75c77dc430e83) 11999829 1024      11719  Jan  1 00:00:00 /foo/bar/DSC_0035.NEF
```
