### PR TITLE
Google Drive Client implemention, first pass.

### DIFF
--- a/drive/google/google.go
+++ b/drive/google/google.go
@@ -1,42 +1,145 @@
 package google
 
-import "github.com/asjoyner/shade/drive"
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"sync"
+
+	gdrive "google.golang.org/api/drive/v3"
+
+	"github.com/asjoyner/shade/drive"
+)
+
+// listFilesQuery is a Google Drive API query string which will return all
+// shade metadata files.
+const listFilesQuery = "appProperties has { key='shadeType' and value='metadata' }"
 
 func init() {
 	drive.RegisterProvider("google", NewClient)
 }
 
 // NewClient returns a new Drive client.
-// TODO(shanel): Should this just be New? or NewDrive?
 func NewClient(c drive.Config) (drive.Client, error) {
-	return &Drive{}, nil
+	client := getOAuthClient(c)
+	service, err := gdrive.New(client)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve Google Drive Client: %v", err)
+	}
+	return &Drive{
+		service: service,
+		config:  c,
+		files:   make(map[string]string),
+	}, nil
 }
 
 // Drive represents access to the Google Drive storage system.
 type Drive struct {
-	config drive.Config
+	service *gdrive.Service
+	config  drive.Config
+
+	mu    sync.RWMutex // protects following members
+	files map[string]string
 }
 
 // ListFiles retrieves all of the File objects known to the client, and returns
 // the corresponding sha256sum of the file object.  Those may be passed to
 // GetChunk() to retrieve the corresponding shade.File.
 func (s *Drive) ListFiles() ([][]byte, error) {
-	return nil, nil
+	ctx := context.TODO() // TODO(cfunkhouser): Get a meaningful context here.
+	r, err := s.service.Files.List().Context(ctx).Q(listFilesQuery).Fields("files(id, name)").Do()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't retrieve files: %v", err)
+	}
+	s.mu.Lock()
+	for _, f := range r.Files {
+		// If decoding the name fails, skip the file.
+		if b, err := hex.DecodeString(f.Name); err == nil {
+			s.files[string(b)] = f.Id
+		}
+	}
+	s.mu.Unlock()
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	resp := make([][]byte, 0, len(s.files))
+	for sha256sum := range s.files {
+		resp = append(resp, []byte(sha256sum))
+	}
+	return resp, nil
 }
 
 // PutFile writes the metadata describing a new file.
-// f should be marshalled JSON, and may be encrypted.
-func (s *Drive) PutFile(sha256, f []byte) error {
+// content should be marshalled JSON, and may be encrypted.
+func (s *Drive) PutFile(sha256sum, content []byte) error {
+	f := &gdrive.File{
+		Name:          hex.EncodeToString(sha256sum),
+		AppProperties: map[string]string{"shadeType": "metadata"},
+	}
+
+	ctx := context.TODO() // TODO(cfunkhouser): Get a meaningful context here.
+	br := bytes.NewReader(content)
+	if _, err := s.service.Files.Create(f).Context(ctx).Media(br).Do(); err != nil {
+		return fmt.Errorf("couldn't create file: %v", err)
+	}
 	return nil
 }
 
 // GetChunk retrieves a chunk with a given SHA-256 sum
-func (s *Drive) GetChunk(sha256 []byte) ([]byte, error) {
-	return nil, nil
+func (s *Drive) GetChunk(sha256sum []byte) ([]byte, error) {
+	s.mu.RLock()
+	fileID, ok := s.files[string(sha256sum)]
+	s.mu.RUnlock()
+
+	filename := hex.EncodeToString(sha256sum)
+	if !ok {
+		ctx := context.TODO() // TODO(cfunkhouser): Get a meaningful context here.
+		r, err := s.service.Files.List().Context(ctx).Q(fmt.Sprintf("name = '%s'", filename)).Fields("files(id, name)").Do()
+		if err != nil {
+			return nil, fmt.Errorf("couldn't get metadata for chunk %v: %v", filename, err)
+		}
+		if len(r.Files) != 0 {
+			return nil, fmt.Errorf("got non-unique chunk result for chunk %v", filename)
+		}
+		fileID = r.Files[0].Id
+	}
+
+	resp, err := s.service.Files.Get(fileID).Download()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't download chunk %v: %v", filename, err)
+	}
+	defer resp.Body.Close()
+
+	chunk, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read chunk %v: %v", filename, err)
+	}
+	return chunk, nil
 }
 
 // PutChunk writes a chunk and returns its SHA-256 sum
-func (s *Drive) PutChunk(sha256 []byte, chunk []byte) error {
+func (s *Drive) PutChunk(sha256sum, content []byte) error {
+	s.mu.RLock()
+	_, ok := s.files[string(sha256sum)]
+	s.mu.RUnlock()
+	if ok {
+		return nil // we know this chunk already exists
+	}
+	f := &gdrive.File{
+		Name:          hex.EncodeToString(sha256sum),
+		AppProperties: map[string]string{"shadeType": "chunk"},
+	}
+	if s.config.ChunkParentID != "" {
+		f.AppProperties["parents"] = s.config.ChunkParentID
+	}
+
+	ctx := context.TODO() // TODO(cfunkhouser): Get a meaningful context here.
+	br := bytes.NewReader(content)
+	if _, err := s.service.Files.Create(f).Context(ctx).Media(br).Do(); err != nil {
+		return fmt.Errorf("couldn't create file: %v", err)
+	}
 	return nil
 }
 

--- a/drive/google/google.go
+++ b/drive/google/google.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"bytes"
-	"context"
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
@@ -11,6 +10,8 @@ import (
 	gdrive "google.golang.org/api/drive/v3"
 
 	"github.com/asjoyner/shade/drive"
+
+	"golang.org/x/net/context"
 )
 
 // listFilesQuery is a Google Drive API query string which will return all

--- a/drive/google/oauth.go
+++ b/drive/google/oauth.go
@@ -1,0 +1,99 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/asjoyner/shade"
+	"github.com/asjoyner/shade/drive"
+
+	gdrive "google.golang.org/api/drive/v3"
+
+	"golang.org/x/oauth2"
+)
+
+const (
+	clientID     = "1060319012426-gb2f7picjh3dfsoni203rkmsjliqok1f.apps.googleusercontent.com"
+	clientSecret = "jfcCV2384sXBlqdaes26bAA5"
+	authURL      = "https://accounts.google.com/o/oauth2/auth"
+	tokenURL     = "https://accounts.google.com/o/oauth2/token"
+	redirectURI  = "https://localhost"
+)
+
+var scope = []string{gdrive.DriveAppdataScope, gdrive.DriveFileScope}
+
+func getOAuthClient(c drive.Config) *http.Client {
+	conf := &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		Scopes:       scope,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  authURL,
+			TokenURL: tokenURL,
+		},
+		RedirectURL: redirectURI,
+	}
+	if c.OAuth.ClientID != "" {
+		conf.ClientID = c.OAuth.ClientID
+	}
+	if c.OAuth.ClientSecret != "" {
+		conf.ClientSecret = c.OAuth.ClientSecret
+	}
+	return getClient(context.TODO(), conf)
+}
+
+func getClient(ctx context.Context, config *oauth2.Config) *http.Client {
+	cacheFile := filepath.Join(shade.ConfigDir(), "google.token")
+	tok, err := tokenFromFile(cacheFile)
+	if err != nil {
+		tok = fetchToken(config)
+		saveToken(cacheFile, tok)
+	}
+	return config.Client(ctx, tok)
+}
+
+// fetchToken uses Config to request a Token.
+func fetchToken(config *oauth2.Config) *oauth2.Token {
+	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
+	fmt.Printf("Go to the following link in your browser then type the "+
+		"authorization code: \n%v\n", authURL)
+
+	var code string
+	if _, err := fmt.Scan(&code); err != nil {
+		log.Fatalf("Unable to read authorization code %v", err)
+	}
+	log.Printf("Read code: %q", code)
+
+	// TODO(cfunkhouser): Get a meaningful context here.
+	tok, err := config.Exchange(context.TODO(), code)
+	if err != nil {
+		log.Fatalf("Unable to retrieve token from web %v", err)
+	}
+	return tok
+}
+
+func tokenFromFile(file string) (*oauth2.Token, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	t := &oauth2.Token{}
+	err = json.NewDecoder(f).Decode(t)
+	defer f.Close()
+	return t, err
+}
+
+func saveToken(file string, token *oauth2.Token) {
+	fmt.Printf("Saving credential file to: %s\n", file)
+	f, err := os.Create(file)
+	if err != nil {
+		log.Fatalf("Unable to cache oauth token: %v", err)
+	}
+	defer f.Close()
+	json.NewEncoder(f).Encode(token)
+}

--- a/drive/google/oauth.go
+++ b/drive/google/oauth.go
@@ -1,7 +1,6 @@
 package google
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -14,6 +13,7 @@ import (
 
 	gdrive "google.golang.org/api/drive/v3"
 
+	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 
@@ -60,14 +60,14 @@ func getClient(ctx context.Context, config *oauth2.Config) *http.Client {
 // fetchToken uses Config to request a Token.
 func fetchToken(config *oauth2.Config) *oauth2.Token {
 	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
-	fmt.Printf("Go to the following link in your browser then type the "+
-		"authorization code: \n%v\n", authURL)
+	fmt.Printf("Visit this URL in your browser: \n%v\n", authURL)
 
 	var code string
+	fmt.Print("Enter your authorization code: ")
 	if _, err := fmt.Scan(&code); err != nil {
 		log.Fatalf("Unable to read authorization code %v", err)
 	}
-	log.Printf("Read code: %q", code)
+	log.Printf("\nRead code: %q\n", code)
 
 	// TODO(cfunkhouser): Get a meaningful context here.
 	tok, err := config.Exchange(context.TODO(), code)


### PR DESCRIPTION
This implementation has worked for trivial writes and retrievals against Google Drive. Instead of using folders to organize the chunks, this implementation adds a "shadeType" AppProperty to the chunk file metadata on create, with possible values "chunk" or "metadata," and filters on that during list operations.
