### PR TITLE
Use Google Drive AppData folder instead of cluttering GDrive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ _testmain.go
 cmd/shade/shade
 cmd/shadeutil/shadeutil
 cmd/throw/throw
+
+# A spot to keep local data inside the workspace.
+localdata/*

--- a/drive/google/google.go
+++ b/drive/google/google.go
@@ -47,8 +47,9 @@ type Drive struct {
 // GetChunk() to retrieve the corresponding shade.File.
 func (s *Drive) ListFiles() ([][]byte, error) {
 	ctx := context.TODO() // TODO(cfunkhouser): Get a meaningful context here.
-	// this query is a Google Drive API query string which will return all
-	// shade metadata files, optionally restricted to a FileParentID
+	// This query is a Google Drive API query string which will return all
+	// shade metadata files. If FileParentID is specified, the query is restricted
+	// there and space "drive" is used; otherwise, space "appDataFolder" is used.
 	q := "appProperties has { key='shadeType' and value='file' }"
 	spaces := "appDataFolder"
 	if s.config.FileParentID != "" {
@@ -149,7 +150,6 @@ func (s *Drive) PutChunk(sha256sum, content []byte, _ *shade.File) error {
 	if ok {
 		return nil // we know this chunk already exists
 	}
-	// A chunk file is always parented to the appDataFolder
 	f := &gdrive.File{
 		Name:          hex.EncodeToString(sha256sum),
 		AppProperties: map[string]string{"shadeType": "chunk"},


### PR DESCRIPTION
When either `FileParentID` or `ChunkParentID` are omitted from a Google Drive configuration, store those files in the hidden app data folder instead. The app data folder is not manageable through the Google Drive web interface (except to wholesale delete all app data), so shade storage will not clutter the Google Drive file manager interface.